### PR TITLE
Fix analytics template JSON syntax

### DIFF
--- a/web/templates/analytics.html
+++ b/web/templates/analytics.html
@@ -408,10 +408,10 @@
         // Analytics data from server
         const analyticsData = {
             hourlyActivity: {{ json .Stats.HourlyActivity }},
-        topCountries: { { json.Stats.TopCountries; } },
-        deviceBreakdown: { { json.Stats.DeviceBreakdown; } },
-        customerActivity: { { json.Stats.CustomerActivity; } }
-    };
+            topCountries: {{ json .Stats.TopCountries }},
+            deviceBreakdown: {{ json .Stats.DeviceBreakdown }},
+            customerActivity: {{ json .Stats.CustomerActivity }}
+        };
 
         // Initialize charts
         initializeCharts();


### PR DESCRIPTION
## Summary
- fix Go template syntax in analyticsData object

## Testing
- `go test ./...` *(fails: debug.go:1:2: expected 'package', found 'EOF')*

------
https://chatgpt.com/codex/tasks/task_e_68424495e458832091e16f2a4ddd4c20